### PR TITLE
Make SimpleVideoImput warning free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(FFmpeg REQUIRED)
 
 # Options
 
-option(WITH_EXAMPLES "add example projects" FALSE)
+option(WITH_EXAMPLES "add example projects" TRUE)
 if (WITH_EXAMPLES)
 	add_subdirectory(examples)
 endif (WITH_EXAMPLES)

--- a/examples/basic_example.cpp
+++ b/examples/basic_example.cpp
@@ -14,12 +14,19 @@ int main(int argc, char *argv[])
 	int count = 0;
         cv::namedWindow("SimpleVideoInput", CV_WINDOW_NORMAL|CV_WINDOW_OPENGL);
         cv::resizeWindow("SimpleVideoInput", 1280, 720);
+        int minTimeValue = 30;
 
 	while (v.read(image)) {
-		std::cout << "Read Frame #" << count++ << " (" << v.millisecondsPerFrame() << "ms)" << std::endl;
+
+                if (v.millisecondsPerFrame() > 0)
+                    minTimeValue = v.millisecondsPerFrame();
+                else
+                    minTimeValue = 30;
+
+		std::cout << "Read Frame #" << count++ << " (" << minTimeValue << "ms)" << std::endl;
 
 		cv::imshow("SimpleVideoInput", image);
-		if (cv::waitKey(v.millisecondsPerFrame()) == 'q')
+		if (cv::waitKey(minTimeValue) == 'q')
 			break;
 	}
 		

--- a/examples/basic_example.cpp
+++ b/examples/basic_example.cpp
@@ -12,10 +12,13 @@ int main(int argc, char *argv[])
 	svi::SimpleVideoInput v(argv[1]);
 	cv::Mat image;
 	int count = 0;
+        cv::namedWindow("SimpleVideoInput", CV_WINDOW_NORMAL|CV_WINDOW_OPENGL);
+        cv::resizeWindow("SimpleVideoInput", 1280, 720);
+
 	while (v.read(image)) {
 		std::cout << "Read Frame #" << count++ << " (" << v.millisecondsPerFrame() << "ms)" << std::endl;
 
-		cv::imshow("Current frame", image);
+		cv::imshow("SimpleVideoInput", image);
 		if (cv::waitKey(v.millisecondsPerFrame()) == 'q')
 			break;
 	}

--- a/examples/basic_example.cpp
+++ b/examples/basic_example.cpp
@@ -3,6 +3,9 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <iostream>
 
+#define MS_PER_FRAME_MINI  30
+
+
 int main(int argc, char *argv[])
 {
 	if (argc < 2) {
@@ -14,14 +17,14 @@ int main(int argc, char *argv[])
 	int count = 0;
         cv::namedWindow("SimpleVideoInput", CV_WINDOW_NORMAL|CV_WINDOW_OPENGL);
         cv::resizeWindow("SimpleVideoInput", 1280, 720);
-        int minTimeValue = 30;
+        int minTimeValue = MS_PER_FRAME_MINI;
 
 	while (v.read(image)) {
 
                 if (v.millisecondsPerFrame() > 0)
                     minTimeValue = v.millisecondsPerFrame();
                 else
-                    minTimeValue = 30;
+                    minTimeValue = MS_PER_FRAME_MINI;
 
 		std::cout << "Read Frame #" << count++ << " (" << minTimeValue << "ms)" << std::endl;
 


### PR DESCRIPTION
Hello,

I modified a bit your code, to make it compile warnings free + I fixed several issues (like reordering some operations) to make it work as expected. On the video side - without sync yet- it works IMHO very well.

Consider the code (I mean the current PR) under MIT license, and ask me if something is not ok.

Thanks,
ericb


